### PR TITLE
fix print statement

### DIFF
--- a/arango_datasets/datasets.py
+++ b/arango_datasets/datasets.py
@@ -157,10 +157,9 @@ class Datasets:
         :return: The collection.
         :rtype: arango.collection.StandardCollection
         """
-        if self.preserve_existing is False:
-            m = f"Collection '{collection_name}' already exists, dropping and creating with new data."  # noqa: E501
-            print(m)
+        print(f"Initializing collection '{collection_name}'")
 
+        if self.preserve_existing is False:
             self.user_db.delete_collection(collection_name, ignore_missing=True)
 
         return self.user_db.create_collection(collection_name, edge=is_edge)

--- a/arango_datasets/datasets.py
+++ b/arango_datasets/datasets.py
@@ -159,7 +159,7 @@ class Datasets:
         """
         print(f"Initializing collection '{collection_name}'")
 
-        if self.preserve_existing is False:
+        if not self.preserve_existing:
             self.user_db.delete_collection(collection_name, ignore_missing=True)
 
         return self.user_db.create_collection(collection_name, edge=is_edge)


### PR DESCRIPTION
We currently always log `Collection '{name}' already exists, dropping and creating with new data.` even if the collection doesn't exist.

Generalizes the print statement to `Initializing collection '{name}'`